### PR TITLE
Hotfix driver 1.0

### DIFF
--- a/test_app.c
+++ b/test_app.c
@@ -7,6 +7,7 @@
 #include "gpio_tm4c123gh6pm.h"
 #include "uart_tm4c123gh6pm.h"
 #include <string.h>
+#include "tm4c123gh6pm.h"
 
 
 #define MAX_SIZE 40
@@ -25,6 +26,8 @@ void init_clock(void)
 }
 
 
+
+#define UART0_ENABLE  ((uint8_t)0x01UL)
 
 int8_t init_gpio(void)
 {
@@ -255,7 +258,7 @@ int main()
 
     init_gpio();
 
-    gpio_write_pin(GPIOF, 1, ENABLE);
+    gpio_write_pin(GPIOF, 2, ENABLE);
 
     clear_screen();
 
@@ -265,7 +268,7 @@ int main()
     {
         while(gpio_read_pin(GPIOF, 4));
 
-        gpio_write_pin(GPIOF, 1, DISABLE);
+        gpio_write_pin(GPIOF, 2, DISABLE);
         gpio_write_pin(GPIOF, 3, ENABLE);
 
         uart_read(UART0, message, 20);

--- a/uart_tm4c123gh6pm.c
+++ b/uart_tm4c123gh6pm.c
@@ -64,6 +64,23 @@
 /******************************************************************************/
 
 
+
+static uint8_t uart_check_port_address(uart_periph_t *p_uart_x)
+{
+    uint8_t func_retval = 0;
+
+    if( p_uart_x == UART0 || p_uart_x == UART1 || p_uart_x == UART2 || p_uart_x == UART4 || p_uart_x == UART4 || p_uart_x == UART5 || p_uart_x == UART6 || p_uart_x == UART7 )
+    {
+        func_retval = 0;
+    }
+    else
+    {
+        func_retval = 1;
+    }
+
+    return func_retval;
+}
+
 /*
  * @brief   helper function to enable UART Peripheral Clock (Blocks till peripheral is ready)
  * @param   *p_uart_x : pointer to the GPIO UART structure (gpio_port_t).
@@ -75,11 +92,7 @@ static int8_t uart_clock_enable(uart_periph_t *p_uart_x)
     int8_t   func_retval = 0;        /*!< Return value of the function                   */
 
     /* Check for correct function parameter value */
-    if(p_uart_x == NULL || p_uart_x != UART0 || p_uart_x != UART1 || p_uart_x != UART2 || p_uart_x != UART3  )
-    {
-        func_retval = -1;
-    }
-    else if(p_uart_x != UART4 || p_uart_x != UART5 || p_uart_x != UART6 || p_uart_x != UART7)
+    if(p_uart_x == NULL || uart_check_port_address(p_uart_x))
     {
         func_retval = -1;
     }

--- a/uart_tm4c123gh6pm.c
+++ b/uart_tm4c123gh6pm.c
@@ -64,7 +64,11 @@
 /******************************************************************************/
 
 
-
+/*
+ * @brief   helper function to check UART port address
+ * @param   *p_uart_x : pointer to the UART structure (uart_periph_t).
+ * @retval  int8_t    : error = 1, success = 0
+ */
 static uint8_t uart_check_port_address(uart_periph_t *p_uart_x)
 {
     uint8_t func_retval = 0;
@@ -83,7 +87,7 @@ static uint8_t uart_check_port_address(uart_periph_t *p_uart_x)
 
 /*
  * @brief   helper function to enable UART Peripheral Clock (Blocks till peripheral is ready)
- * @param   *p_uart_x : pointer to the GPIO UART structure (gpio_port_t).
+ * @param   *p_uart_x : pointer to the UART structure (uart_periph_t).
  * @retval  int8_t    : error = -1, success = 0
  */
 static int8_t uart_clock_enable(uart_periph_t *p_uart_x)
@@ -160,6 +164,7 @@ static int8_t uart_clock_enable(uart_periph_t *p_uart_x)
 
     return func_retval;
 }
+
 
 
 static uint16_t get_system_clock_frequency()


### PR DESCRIPTION
fix added to static function in (uart_tm4c123gh6pm.h) :- 
`uart_clock_enable(uart_periph_t *p_uart_x)`

static function added to check if correct port is entered or not
uart_check_port_address(uart_periph_t *p_uart_x)